### PR TITLE
Add option for skipping RTP header size insufficient for extension error

### DIFF
--- a/internal/rtsp/custom.go
+++ b/internal/rtsp/custom.go
@@ -1,0 +1,5 @@
+package rtsp
+
+var (
+	skipErrorRTPHeaderSizeInsufficient bool
+)

--- a/pkg/rtsp/conn.go
+++ b/pkg/rtsp/conn.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -32,6 +33,9 @@ type Conn struct {
 	Medias    []*core.Media
 	UserAgent string
 	URL       *url.URL
+
+	// public custom
+	SkipErrorRTPHeaderSizeInsufficient bool
 
 	// internal
 
@@ -68,6 +72,10 @@ const (
 	MethodPause    = "PAUSE"
 	MethodAnnounce = "ANNOUNCE"
 	MethodRecord   = "RECORD"
+)
+
+const (
+	errRTPHeaderSizeInsufficientForExtensionStr = "RTP header size insufficient for extension"
 )
 
 type State byte
@@ -239,7 +247,14 @@ func (c *Conn) Handle() (err error) {
 		if channelID&1 == 0 {
 			packet := &rtp.Packet{}
 			if err = packet.Unmarshal(buf); err != nil {
-				return
+				// Skip for error RTP header size insufficient for extension
+				if c.SkipErrorRTPHeaderSizeInsufficient {
+					if !strings.Contains(err.Error(), errRTPHeaderSizeInsufficientForExtensionStr) {
+						return
+					}
+				} else {
+					return
+				}
 			}
 
 			for _, receiver := range c.receivers {


### PR DESCRIPTION
## Problem
The RTSP connection automatically restarts when encountering the error message "RTP header size insufficient for extension."

## Solution
This PR introduces an option to skip the aforementioned error by adding a configuration option `skip_error_rtp_header_size_insufficient` under the `rtsp` path. This enhancement prevents the RTSP connection from restarting unnecessarily.

## POW
![image](https://github.com/HYBIOT/go2rtc/assets/34341154/95d82437-c30a-4c4b-afe0-42e0a3b8ff75)

