### PR TITLE
Add bitrate to webrtc/mse/mp4 consumer info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ go2rtc.yaml
 go2rtc.json
 
 0_test.go
+
+.goreload

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+dev:
+	goreload .

--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -100,6 +100,7 @@ type Info struct {
 	Senders    []*Sender   `json:"senders,omitempty"`
 	Recv       int         `json:"recv,omitempty"`
 	Send       int         `json:"send,omitempty"`
+	Bitrate    int         `json:"bitrate,omitempty"` // bytes per second
 }
 
 const (
@@ -147,6 +148,7 @@ type SuperConsumer struct {
 	Medias     []*Media  `json:"medias,omitempty"`
 	Senders    []*Sender `json:"senders,omitempty"`
 	Send       int       `json:"send,omitempty"`
+	Bitrate    int       `json:"bitrate,omitempty"` // bytes per second
 }
 
 func (s *SuperConsumer) GetMedias() []*Media {

--- a/pkg/custom/custom.go
+++ b/pkg/custom/custom.go
@@ -1,0 +1,21 @@
+package custom
+
+import (
+	"time"
+)
+
+func StartBitrateWorker(send, bitrate *int, stop chan struct{}) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	prevSendBytes := *send
+	for {
+		select {
+		case <-ticker.C:
+			*bitrate = *send - prevSendBytes
+			prevSendBytes = *send
+		case <-stop:
+			return
+		}
+	}
+}

--- a/pkg/isapi/consumer.go
+++ b/pkg/isapi/consumer.go
@@ -2,6 +2,7 @@ package isapi
 
 import (
 	"encoding/json"
+
 	"github.com/AlexxIT/go2rtc/pkg/core"
 	"github.com/pion/rtp"
 )
@@ -52,9 +53,10 @@ func (c *Client) Stop() (err error) {
 
 func (c *Client) MarshalJSON() ([]byte, error) {
 	info := &core.Info{
-		Type:   "ISAPI active consumer",
-		Medias: c.medias,
-		Send:   c.send,
+		Type:    "ISAPI active consumer",
+		Medias:  c.medias,
+		Send:    c.send,
+		Bitrate: c.bitrate,
 	}
 	if c.sender != nil {
 		info.Senders = []*core.Sender{c.sender}

--- a/pkg/isapi/custom.go
+++ b/pkg/isapi/custom.go
@@ -1,0 +1,8 @@
+package isapi
+
+import "github.com/AlexxIT/go2rtc/pkg/custom"
+
+func (c *Client) startBitrateWorker() {
+	c.stopBitrateWorker = make(chan struct{})
+	go custom.StartBitrateWorker(&c.send, &c.bitrate, c.stopBitrateWorker)
+}

--- a/pkg/mp4/consumer.go
+++ b/pkg/mp4/consumer.go
@@ -23,6 +23,8 @@ type Consumer struct {
 	Rotate int `json:"-"`
 	ScaleX int `json:"-"`
 	ScaleY int `json:"-"`
+
+	stopBitrateWorker chan struct{}
 }
 
 func NewConsumer(medias []*core.Media) *Consumer {
@@ -52,6 +54,7 @@ func NewConsumer(medias []*core.Media) *Consumer {
 		wr:    core.NewWriteBuffer(nil),
 	}
 	cons.Medias = medias
+	cons.startBitrateWorker()
 	return cons
 }
 
@@ -185,5 +188,6 @@ func (c *Consumer) WriteTo(wr io.Writer) (int64, error) {
 
 func (c *Consumer) Stop() error {
 	_ = c.SuperConsumer.Close()
+	c.stopBitrateWorker <- struct{}{}
 	return c.wr.Close()
 }

--- a/pkg/mp4/custom.go
+++ b/pkg/mp4/custom.go
@@ -1,0 +1,8 @@
+package mp4
+
+import "github.com/AlexxIT/go2rtc/pkg/custom"
+
+func (c *Consumer) startBitrateWorker() {
+	c.stopBitrateWorker = make(chan struct{})
+	go custom.StartBitrateWorker(&c.SuperConsumer.Send, &c.SuperConsumer.Bitrate, c.stopBitrateWorker)
+}

--- a/pkg/webrtc/conn.go
+++ b/pkg/webrtc/conn.go
@@ -28,6 +28,9 @@ type Conn struct {
 	offer  string
 	remote string
 	closed core.Waiter
+
+	bitrate           int // bytes per second
+	stopBitrateWorker chan struct{}
 }
 
 func NewConn(pc *webrtc.PeerConnection) *Conn {
@@ -127,11 +130,14 @@ func NewConn(pc *webrtc.PeerConnection) *Conn {
 		}
 	})
 
+	c.startBitrateWorker()
+
 	return c
 }
 
 func (c *Conn) Close() error {
 	c.closed.Done(nil)
+	c.stopBitrateWorker <- struct{}{}
 	return c.pc.Close()
 }
 

--- a/pkg/webrtc/consumer.go
+++ b/pkg/webrtc/consumer.go
@@ -93,6 +93,7 @@ func (c *Conn) MarshalJSON() ([]byte, error) {
 		Senders:    c.senders,
 		Recv:       c.recv,
 		Send:       c.send,
+		Bitrate:    c.bitrate,
 	}
 	return json.Marshal(info)
 }

--- a/pkg/webrtc/custom.go
+++ b/pkg/webrtc/custom.go
@@ -1,0 +1,10 @@
+package webrtc
+
+import (
+	"github.com/AlexxIT/go2rtc/pkg/custom"
+)
+
+func (c *Conn) startBitrateWorker() {
+	c.stopBitrateWorker = make(chan struct{})
+	go custom.StartBitrateWorker(&c.send, &c.bitrate, c.stopBitrateWorker)
+}


### PR DESCRIPTION
## What happen?

Want to add bitrate information to webrtc, mse and mp4 consumer

## Insight

- Add bitrate calculation worker
- Add bitrate to consumer client objects
- Add pkg `custom`
- Add goreload (for development)

## POW

![Screenshot 2567-04-30 at 15 21 26](https://github.com/HYBIOT/go2rtc/assets/34341154/e5030fad-03ab-4d18-9910-2bd8f38d3732)

