### PR TITLE
Create multiple stream sources via API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ go2rtc.json
 0_test.go
 
 .DS_Store
+
+.goreload


### PR DESCRIPTION
## What happen?

Want to enhance create-stream API to support multiple sources

## Insight

- Enhance create-stream API to extract `src` separated by `,` (comma) and create new stream with multiple sources
- Ignore .goreload

## POW

<img width="1232" alt="Screenshot 2567-05-12 at 15 16 10" src="https://github.com/HYBIOT/go2rtc/assets/34341154/aa880cb7-98ed-4c36-9d12-1bb70a775294">
<img width="916" alt="Screenshot 2567-05-12 at 15 16 37" src="https://github.com/HYBIOT/go2rtc/assets/34341154/de2e8c15-38d7-4e28-b9f7-dca456e42c5b">
