### PR TITLE
Fix stream consumer stuck after closing bitrate worker

### DIFF
--- a/pkg/isapi/custom.go
+++ b/pkg/isapi/custom.go
@@ -3,6 +3,6 @@ package isapi
 import "github.com/AlexxIT/go2rtc/pkg/custom"
 
 func (c *Client) startBitrateWorker() {
-	c.stopBitrateWorker = make(chan struct{})
+	c.stopBitrateWorker = make(chan struct{}, 1)
 	go custom.StartBitrateWorker(&c.send, &c.bitrate, c.stopBitrateWorker)
 }

--- a/pkg/mp4/custom.go
+++ b/pkg/mp4/custom.go
@@ -3,6 +3,6 @@ package mp4
 import "github.com/AlexxIT/go2rtc/pkg/custom"
 
 func (c *Consumer) startBitrateWorker() {
-	c.stopBitrateWorker = make(chan struct{})
+	c.stopBitrateWorker = make(chan struct{}, 1)
 	go custom.StartBitrateWorker(&c.SuperConsumer.Send, &c.SuperConsumer.Bitrate, c.stopBitrateWorker)
 }

--- a/pkg/webrtc/custom.go
+++ b/pkg/webrtc/custom.go
@@ -5,6 +5,6 @@ import (
 )
 
 func (c *Conn) startBitrateWorker() {
-	c.stopBitrateWorker = make(chan struct{})
+	c.stopBitrateWorker = make(chan struct{}, 1)
 	go custom.StartBitrateWorker(&c.send, &c.bitrate, c.stopBitrateWorker)
 }


### PR DESCRIPTION
## What happen?

Stream consumer got stuck after closing bitrate worker.

## Insight

Add buffer when initialize `stopBitrateWorker`.

## POW

![image](https://github.com/HYBIOT/go2rtc/assets/34341154/07c97af1-1cde-44a0-83c7-75139e0d4823)
