### PR TITLE
Fix JPEG snapshot timeout

### DIFF
--- a/pkg/core/custom.go
+++ b/pkg/core/custom.go
@@ -25,5 +25,7 @@ func (c *Connection) StartBitrateWorker() {
 }
 
 func (c *Connection) StopBitrateWorker() {
-	c.stopBitrateWorker <- struct{}{}
+	if c.stopBitrateWorker != nil {
+		c.stopBitrateWorker <- struct{}{}
+	}
 }


### PR DESCRIPTION
## What happen?

Cannot call JPEG snapshot API (timeout).

## Insight

Check if `stopBitrateWorker` is null before using.

## POW

https://github.com/HYBIOT/go2rtc/assets/34341154/48d5f624-53a8-4f68-8ac1-c5c6f137b712