### PR TITLE
Control RTSP stream speed

### DIFF
--- a/internal/streams/custom.go
+++ b/internal/streams/custom.go
@@ -1,0 +1,58 @@
+package streams
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/AlexxIT/go2rtc/pkg/rtsp"
+)
+
+// only support RTSP sources
+func apiStreamsSpeed(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	streamName := query.Get("name")
+
+	if streamName == "" {
+		http.Error(w, "name required", http.StatusBadRequest)
+		return
+	}
+
+	switch r.Method {
+	case "PUT":
+		streamsMu.RLock()
+		stream := Get(streamName)
+		defer streamsMu.RUnlock()
+
+		if stream == nil {
+			http.Error(w, "", http.StatusNotFound)
+			return
+		}
+
+		speedStr := query.Get("speed")
+		if speedStr == "" {
+			http.Error(w, "speed required", http.StatusBadRequest)
+			return
+		}
+
+		_, err := strconv.ParseFloat(speedStr, 64)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		for _, producer := range stream.producers {
+			if conn, ok := producer.conn.(*rtsp.Conn); ok {
+				conn.Connection.Speed = speedStr
+				err := conn.Play()
+				if err != nil {
+					log.Error().Msgf("[stream] conn.Play(): %+v\n", err)
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+			}
+		}
+
+		return
+	}
+
+	http.Error(w, "", http.StatusNotFound)
+}

--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -29,6 +29,9 @@ func Init() {
 	api.HandleFunc("api/streams", apiStreams)
 	api.HandleFunc("api/streams.dot", apiStreamsDOT)
 
+	// custom
+	api.HandleFunc("api/custom/streams/speed", apiStreamsSpeed)
+
 	if cfg.Publish == nil {
 		return
 	}

--- a/pkg/core/connection.go
+++ b/pkg/core/connection.go
@@ -50,8 +50,10 @@ type Connection struct {
 
 	Transport any `json:"-"`
 
+	// custom
 	stopBitrateWorker chan struct{} `json:"-"`
 	Bitrate           int           `json:"bitrate,omitempty"` // bytes per second
+	Speed             string        `json:"speed,omitempty"`   // empty string indicates normal speed
 }
 
 func (c *Connection) GetMedias() []*Media {

--- a/pkg/rtsp/client.go
+++ b/pkg/rtsp/client.go
@@ -313,6 +313,11 @@ func (c *Conn) SetupMedia(media *core.Media) (byte, error) {
 
 func (c *Conn) Play() (err error) {
 	req := &tcp.Request{Method: MethodPlay, URL: c.URL}
+	if c.Speed != "" {
+		req.Header = map[string][]string{
+			"Scale": {c.Speed},
+		}
+	}
 	return c.WriteRequest(req)
 }
 


### PR DESCRIPTION
## What happen?

Want to control the RTSP source (producer) speed by setting the `Scale` header when sending the `PLAY` method.
([RFC7826](https://www.rfc-editor.org/rfc/rfc7826.html#section-18.46))

## Insight

**API control stream speed**
- Endpoint: `/api/custom/streams/speed`
- Method: `PUT`
- Parameters: 
  - query `name` => stream name
  - query `speed` => stream speed (e.g. `-1`, `1`, `0.5`, `2`, `4`)
- Response:
  - success: 200 ok
  - error: other status codes

## PoW

https://github.com/HYBIOT/go2rtc/assets/34341154/76be680a-d544-4c05-9882-6b5d11343f05
