### PR TITLE
API remove stream consumers

### DIFF
--- a/internal/streams/custom.go
+++ b/internal/streams/custom.go
@@ -56,3 +56,32 @@ func apiStreamsSpeed(w http.ResponseWriter, r *http.Request) {
 
 	http.Error(w, "", http.StatusNotFound)
 }
+
+func apiStreamsRemoveConsumers(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, "", http.StatusNotFound)
+		return
+	}
+
+	query := r.URL.Query()
+
+	for _, streamName := range query["name"] {
+		if streamName == "" {
+			continue
+		}
+
+		streamsMu.RLock()
+		stream := Get(streamName)
+		streamsMu.RUnlock()
+
+		if stream == nil {
+			continue
+		}
+
+		for _, consumer := range stream.consumers {
+			stream.RemoveConsumer(consumer)
+		}
+	}
+
+	http.Error(w, "", http.StatusOK)
+}

--- a/internal/streams/streams.go
+++ b/internal/streams/streams.go
@@ -31,6 +31,7 @@ func Init() {
 
 	// custom
 	api.HandleFunc("api/custom/streams/speed", apiStreamsSpeed)
+	api.HandleFunc("api/custom/streams.removeConsumers", apiStreamsRemoveConsumers)
 
 	if cfg.Publish == nil {
 		return


### PR DESCRIPTION
## What happen?

Want to force remove stream consumers

## Insight

**API remove stream consumers**
- Endpoint: `/api/custom/streams.removeConsumers`
- Method: `POST`
- Parameters: 
  - query `name` => stream name
- Response:
  - success: 200 ok
  - error: other status codes

## PoW

<img width="1115" alt="Screenshot 2567-08-30 at 10 13 43" src="https://github.com/user-attachments/assets/2f78a4d7-5d48-4f9c-b16f-6a1db52a174c">



