### PR TITLE
Create stream with speed

### DIFF
--- a/internal/streams/api.go
+++ b/internal/streams/api.go
@@ -57,9 +57,14 @@ func apiStreams(w http.ResponseWriter, r *http.Request) {
 			name = src
 		}
 
-		if New(name, query["src"]...) == nil {
+		stream := New(name, query["src"]...)
+		if stream == nil {
 			http.Error(w, "", http.StatusBadRequest)
 			return
+		}
+
+		if speedStr := query.Get("speed"); speedStr != "" {
+			setupStreamSpeed(stream, speedStr)
 		}
 
 		if err := app.PatchConfig(name, query["src"], "streams"); err != nil {

--- a/internal/streams/custom.go
+++ b/internal/streams/custom.go
@@ -1,8 +1,10 @@
 package streams
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/AlexxIT/go2rtc/pkg/rtsp"
 )
@@ -41,6 +43,10 @@ func apiStreamsSpeed(w http.ResponseWriter, r *http.Request) {
 		}
 
 		for _, producer := range stream.producers {
+			if !isISAPIPlayback(producer.url) {
+				continue
+			}
+
 			producer.speed = speedStr
 
 			if conn, ok := producer.conn.(*rtsp.Conn); ok {
@@ -86,4 +92,25 @@ func apiStreamsRemoveConsumers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Error(w, "", http.StatusOK)
+}
+
+func setupStreamSpeed(stream *Stream, speedStr string) {
+	speedFloat, err := strconv.ParseFloat(speedStr, 64)
+	if err != nil {
+		return
+	}
+
+	speedStr3 := fmt.Sprintf("%.3f", speedFloat)
+
+	for _, producer := range stream.producers {
+		if speedStr3 == "1.000" {
+			producer.speed = ""
+		} else {
+			producer.speed = speedStr
+		}
+	}
+}
+
+func isISAPIPlayback(url string) bool {
+	return strings.Contains(url, "/Streaming/tracks")
 }


### PR DESCRIPTION
## What happen?

Want to setup `speed` when creating a stream.

## Insight

- Add a query param named `speed` to API create stream.
- Reject requests for API set custom speed if URL is not ISAPI playback.