### PR TITLE
Custom RTSP speed header

### DIFF
--- a/internal/streams/api.go
+++ b/internal/streams/api.go
@@ -61,7 +61,11 @@ func apiStreams(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if speedStr := query.Get("speed"); speedStr != "" {
-			setupStreamSpeed(stream, speedStr)
+			var speedHeaders []string
+			if query.Has("speed_headers") && len(query["speed_headers"]) > 0 {
+				speedHeaders = query["speed_headers"]
+			}
+			setupStreamSpeed(stream, speedStr, speedHeaders)
 		}
 
 		if err := app.PatchConfig([]string{"streams", name}, query["src"]); err != nil {

--- a/internal/streams/custom.go
+++ b/internal/streams/custom.go
@@ -90,7 +90,7 @@ func apiStreamsRemoveConsumers(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "", http.StatusOK)
 }
 
-func setupStreamSpeed(stream *Stream, speedStr string) {
+func setupStreamSpeed(stream *Stream, speedStr string, speedHeaders []string) {
 	speedFloat, err := strconv.ParseFloat(speedStr, 64)
 	if err != nil {
 		return
@@ -101,8 +101,10 @@ func setupStreamSpeed(stream *Stream, speedStr string) {
 	for _, producer := range stream.producers {
 		if speedStr3 == "1.000" {
 			producer.speed = ""
+			producer.speedHeaders = nil
 		} else {
 			producer.speed = speedStr
+			producer.speedHeaders = speedHeaders
 		}
 	}
 }

--- a/internal/streams/producer.go
+++ b/internal/streams/producer.go
@@ -37,7 +37,8 @@ type Producer struct {
 	workerID int
 
 	// custom
-	speed string
+	speed        string
+	speedHeaders []string
 }
 
 const SourceTemplate = "{input}"
@@ -143,6 +144,9 @@ func (p *Producer) MarshalJSON() ([]byte, error) {
 	if p.speed != "" {
 		info["speed"] = p.speed
 	}
+	if len(p.speedHeaders) > 0 {
+		info["speed_headers"] = strings.Join(p.speedHeaders, ",")
+	}
 	return json.Marshal(info)
 }
 
@@ -164,6 +168,7 @@ func (p *Producer) start() {
 	if p.speed != "" {
 		if conn, ok := p.conn.(*rtsp.Conn); ok {
 			conn.Connection.Speed = p.speed
+			conn.Connection.SpeedHeaders = p.speedHeaders
 		}
 	}
 

--- a/pkg/core/connection.go
+++ b/pkg/core/connection.go
@@ -53,8 +53,9 @@ type Connection struct {
 
 	// custom
 	stopBitrateWorker chan struct{} `json:"-"`
-	Bitrate           int           `json:"bitrate,omitempty"` // bytes per second
-	Speed             string        `json:"speed,omitempty"`   // empty string indicates normal speed
+	Bitrate           int           `json:"bitrate,omitempty"`       // bytes per second
+	Speed             string        `json:"speed,omitempty"`         // empty string indicates normal speed
+	SpeedHeaders      []string      `json:"speed_headers,omitempty"` // custom speed headers for RTSP
 }
 
 func (c *Connection) GetMedias() []*Media {

--- a/pkg/rtsp/client.go
+++ b/pkg/rtsp/client.go
@@ -312,8 +312,13 @@ func (c *Conn) SetupMedia(media *core.Media) (byte, error) {
 func (c *Conn) Play() (err error) {
 	req := &tcp.Request{Method: MethodPlay, URL: c.URL}
 	if c.Speed != "" {
-		req.Header = map[string][]string{
-			"Scale": {c.Speed},
+		req.Header = map[string][]string{}
+		if len(c.SpeedHeaders) > 0 {
+			for _, v := range c.SpeedHeaders {
+				req.Header.Add(v, c.Speed)
+			}
+		} else {
+			req.Header["Scale"] = []string{c.Speed}
 		}
 	}
 	return c.WriteRequest(req)


### PR DESCRIPTION
## What happen?

Want to config RTSP speed headers when creating stream.

## Insight

- Add a query param named `speed_headers` to API create stream.
- Enhance RTSP client